### PR TITLE
Fixed nav text color

### DIFF
--- a/src/styles/scss/header.scss
+++ b/src/styles/scss/header.scss
@@ -38,6 +38,7 @@ Date: 8/15/2022
     }
   
     .active {
+      color: #fff;
       box-shadow: inset 100px 0 0 0 var(--blue);
       border-radius: 20px;
     }


### PR DESCRIPTION
Hey, low contrast on nav elements has been fixed.
<img width="1440" alt="Screenshot" src="https://user-images.githubusercontent.com/42366462/204033799-8df1b5ae-4466-47bb-a617-20c2737b3d22.png">
